### PR TITLE
fix(ipwhois): Remove ipwhois library.

### DIFF
--- a/dns_recon/util.py
+++ b/dns_recon/util.py
@@ -2,7 +2,7 @@
 
 import re
 import os
-from ipwhois import IPWhois
+import whois
 
 class Utility:
     """ Utility methods."""
@@ -26,8 +26,8 @@ class Utility:
     def whois(ip_addr):
         '''Whois Capability by IP address.'''
         try:
-            target = IPWhois(ip_addr)
-            return target.lookup_whois()
+            target = whois.whois(ip_addr)
+            return target
         except ValueError as err:
             print(f"Unexpected {err}, {type(err)}")
             return ("NONE", "NONE")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     install_requires=[
         "dnspython ~= 2.0.0",
-        "ipwhois ~= 1.2.0"
+        "whois ~= 0.8.0"
     ],
     extras_require = {
         "dev": [

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -18,4 +18,4 @@ def test_whois():
     '''Test whois static method.'''
     taget = "151.139.128.14"
     test = Utility.whois(taget)
-    assert test['asn_description'] == 'STACKPATH-CDN, US'
+    assert 'neteng@stackpath.com' in test['emails']


### PR DESCRIPTION
Ipwhois has a conflicting library requirement for dnspython. We are pivoting with another library.